### PR TITLE
Use 1.7 as java target version

### DIFF
--- a/freenet-ext/build.properties
+++ b/freenet-ext/build.properties
@@ -12,7 +12,7 @@ java.class.dirs.user=/usr/share/java
 
 # Javac
 javac.args=-Xlint
-javac.target.version=1.5
+javac.target.version=1.7
 
 # Mirrors to use, before trying upstream sources
 extlib.use-mirrors=fpi

--- a/freenet-ext/build.xml
+++ b/freenet-ext/build.xml
@@ -74,7 +74,7 @@
 		</replace>
 		<echo message="Updated build version to ${git.revision} in ${main.make}/${version.src}"/>
 
-		<javac srcdir="${main.make}" destdir="${main.make}" debug="on" optimize="on" source="1.5" target="1.5">
+		<javac srcdir="${main.make}" destdir="${main.make}" debug="on" optimize="on" source="1.5" target="1.7">
 			<compilerarg line="${javac.args}"/>
 			<include name="${version.src}"/>
 		</javac>


### PR DESCRIPTION
Update java target version to 1.7. Note that it may be problematic to test a build as db4o dependencies is unavailable (www.db4o.com domain is gone).